### PR TITLE
判断两个浮点数是否相等不能用等于，而应该使得二者相减的数，小于一个特别小的数。

### DIFF
--- a/src/main/java/com/github/hcsp/datatype/Main.java
+++ b/src/main/java/com/github/hcsp/datatype/Main.java
@@ -9,6 +9,6 @@ public class Main {
 
     // 判断两个double是否相等
     public static boolean doubleEquals(double a, double b) {
-        return a == b;
+        return a-b<0.0000001;
     }
 }


### PR DESCRIPTION
修复了一个判断浮点类型的数是否相等的Bug.